### PR TITLE
feat: ダウンロードログのUI改善とシードデータの日本語化

### DIFF
--- a/supabase/functions/watermark-image/index.ts
+++ b/supabase/functions/watermark-image/index.ts
@@ -204,6 +204,24 @@ serve(async (req: Request) => {
     })
     debug.log('Image processed successfully');
 
+    // ダウンロードログの保存
+    debug.log('Saving download log...');
+    const { error: logError } = await serviceRoleClient
+      .from('download_logs')
+      .insert({
+        user_id: user.id,
+        image_id: imageId,
+        created_at: new Date().toISOString(),
+        ip_address: req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || 'unknown'
+      });
+
+    if (logError) {
+      debug.error('Failed to save download log:', logError);
+      // ログの保存に失敗しても画像のダウンロードは続行
+    } else {
+      debug.log('Download log saved successfully');
+    }
+
     // 5. レスポンス返却
     const contentType = imageData.original_filename.toLowerCase().endsWith('.png')
       ? 'image/png'

--- a/supabase/migrations/20250423081151_create_download_logs_table.sql
+++ b/supabase/migrations/20250423081151_create_download_logs_table.sql
@@ -1,6 +1,6 @@
 -- 4. DOWNLOAD_LOGS TABLE
 CREATE TABLE public.download_logs (
-  log_id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
   profile_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
   image_id uuid NOT NULL REFERENCES public.images(id) ON DELETE CASCADE,
   client_ip inet NOT NULL,

--- a/supabase/package-lock.json
+++ b/supabase/package-lock.json
@@ -8,6 +8,7 @@
       "name": "markify-supabase",
       "version": "1.0.0",
       "dependencies": {
+        "md5": "^2.3.0",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -2051,6 +2052,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -2157,6 +2166,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -2613,6 +2630,11 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
@@ -3605,6 +3627,16 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/merge-stream": {

--- a/supabase/package.json
+++ b/supabase/package.json
@@ -21,6 +21,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "md5": "^2.3.0",
     "uuid": "^11.1.0"
   }
 }

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -69,17 +69,17 @@ FROM generate_series(2, 31) AS gs(i);
 
 
 -- 4. Seed download_logs (5 logs per image)
-INSERT INTO public.download_logs (log_id, profile_id, image_id, client_ip, created_at, updated_at)
-SELECT
-  md5(format('log-id-%s-%s', i.id, log.j))::uuid AS log_id,
-  -- Cycle through general users for logs
-  md5(format('profile-id-%s', ((log.j - 1) % 30) + 2))::uuid AS profile_id,
-  i.id AS image_id,
-  format('192.168.%s.%s', (random() * 255)::integer, (random() * 255)::integer)::inet AS client_ip,
-  now() - interval '1 day' * (random() * 30)::integer,
-  now() - interval '1 day' * (random() * 30)::integer
-FROM public.images i
-CROSS JOIN generate_series(1, 5) AS log(j);
+-- INSERT INTO public.download_logs (log_id, profile_id, image_id, client_ip, created_at, updated_at)
+-- SELECT
+--   md5(format('log-id-%s-%s', i.id, log.j))::uuid AS log_id,
+--   -- Cycle through general users for logs
+--   md5(format('profile-id-%s', ((log.j - 1) % 30) + 2))::uuid AS profile_id,
+--   i.id AS image_id,
+--   format('192.168.%s.%s', (random() * 255)::integer, (random() * 255)::integer)::inet AS client_ip,
+--   now() - interval '1 day' * (random() * 30)::integer,
+--   now() - interval '1 day' * (random() * 30)::integer
+-- FROM public.images i
+-- CROSS JOIN generate_series(1, 5) AS log(j);
 
 -- ウォーターマーク設定の追加
 insert into public.settings (key, value, description)

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -53,20 +53,48 @@ INSERT INTO public.profiles (id, user_id, code, first_name, last_name, role, cre
 VALUES (
   '00000000-0000-0000-0000-000000000001',
   '00000000-0000-0000-0000-000000000001',
-  'admin001', 'Admin', 'User', 'admin', now(), now()
+  'admin001', '太郎', '山田', 'admin', now(), now()
 );
 
 -- General user profiles via generate_series
+WITH japanese_names AS (
+  SELECT
+    gs.i,
+    CASE (gs.i % 10)
+      WHEN 0 THEN '佐藤'
+      WHEN 1 THEN '鈴木'
+      WHEN 2 THEN '高橋'
+      WHEN 3 THEN '田中'
+      WHEN 4 THEN '伊藤'
+      WHEN 5 THEN '渡辺'
+      WHEN 6 THEN '山本'
+      WHEN 7 THEN '中村'
+      WHEN 8 THEN '小林'
+      WHEN 9 THEN '加藤'
+    END as last_name,
+    CASE (gs.i % 10)
+      WHEN 0 THEN '翔太'
+      WHEN 1 THEN '陽菜'
+      WHEN 2 THEN '大輝'
+      WHEN 3 THEN '結衣'
+      WHEN 4 THEN '悠真'
+      WHEN 5 THEN '美咲'
+      WHEN 6 THEN '颯太'
+      WHEN 7 THEN '莉子'
+      WHEN 8 THEN '蓮'
+      WHEN 9 THEN '優花'
+    END as first_name
+  FROM generate_series(2, 31) AS gs(i)
+)
 INSERT INTO public.profiles (id, user_id, code, first_name, last_name, role, created_at, updated_at)
 SELECT
-  md5(format('profile-id-%s', gs.i))::uuid AS id,
-  md5(format('user-id-%s', gs.i))::uuid AS user_id,
-  'user' || to_char(gs.i - 1, 'FM000') AS code,
-  'First' || to_char(gs.i - 1, 'FM000') AS first_name,
-  'Last' || to_char(gs.i - 1, 'FM000') AS last_name,
+  md5(format('profile-id-%s', jn.i))::uuid AS id,
+  md5(format('user-id-%s', jn.i))::uuid AS user_id,
+  'user' || to_char(jn.i - 1, 'FM000') AS code,
+  jn.first_name,
+  jn.last_name,
   'general', now(), now()
-FROM generate_series(2, 31) AS gs(i);
-
+FROM japanese_names jn;
 
 -- 4. Seed download_logs (5 logs per image)
 -- INSERT INTO public.download_logs (log_id, profile_id, image_id, client_ip, created_at, updated_at)

--- a/vite-app-ant/src/App.tsx
+++ b/vite-app-ant/src/App.tsx
@@ -51,7 +51,10 @@ function App() {
                     create: "/images/create",
                     edit: "/images/edit/:id",
                     show: "/images/show/:id",
-                    meta: { canDelete: true },
+                    meta: {
+                      canDelete: true,
+                      label: "画像管理"
+                    },
                   },
                   // 管理者メニューは一般ユーザーには一切表示されません
                   ...(isAdmin ? [
@@ -68,7 +71,10 @@ function App() {
                       create: "/profiles/create",
                       edit: "/profiles/edit/:id",
                       show: "/profiles/show/:id",
-                      meta: { canDelete: true },
+                      meta: {
+                        canDelete: true,
+                        label: "プロフィール管理"
+                      },
                     },
                     {
                       name: "download_logs",
@@ -76,12 +82,18 @@ function App() {
                       create: "/download_logs/create",
                       edit: "/download_logs/edit/:id",
                       show: "/download_logs/show/:id",
-                      meta: { canDelete: true },
-                      options: { group: "管理者メニュー" },
+                      meta: {
+                        canDelete: true,
+                        label: "ダウンロード履歴",
+                        options: { group: "管理者メニュー" }
+                      },
                     },
                     {
                       name: "settings",
-                      meta: { label: "設定", icon: <SettingOutlined /> },
+                      meta: {
+                        label: "設定",
+                        icon: <SettingOutlined />
+                      },
                       list: "/settings/watermark",
                       options: { group: "管理者メニュー" },
                     },

--- a/vite-app-ant/src/components/DebugUserSelect.tsx
+++ b/vite-app-ant/src/components/DebugUserSelect.tsx
@@ -62,4 +62,4 @@ export const DebugUserSelect: React.FC<DebugUserSelectProps> = ({ onUserSelect }
       />
     </div>
   );
-}; 
+};

--- a/vite-app-ant/src/pages/download_logs/list.tsx
+++ b/vite-app-ant/src/pages/download_logs/list.tsx
@@ -1,5 +1,89 @@
-import { AntdInferencer } from "@refinedev/inferencer/antd";
+import React from "react";
+import { BaseRecord, useMany } from "@refinedev/core";
+import {
+    useTable,
+    List,
+    EditButton,
+    ShowButton,
+    DeleteButton,
+    DateField,
+} from "@refinedev/antd";
+import { Table, Space } from "antd";
 
 export const DownloadLogsList = () => {
-    return <AntdInferencer />;
+    const { tableProps } = useTable({
+        syncWithLocation: true,
+    });
+
+    const { data: profileData, isLoading: profileIsLoading } = useMany({
+        resource: "profiles",
+        ids: tableProps?.dataSource?.map((item) => item?.profile_id) ?? [],
+        queryOptions: {
+            enabled: !!tableProps?.dataSource,
+        },
+    });
+
+    const { data: imageData, isLoading: imageIsLoading } = useMany({
+        resource: "images",
+        ids: tableProps?.dataSource?.map((item) => item?.image_id) ?? [],
+        queryOptions: {
+            enabled: !!tableProps?.dataSource,
+        },
+    });
+
+    return (
+        // ヘッダーボタンを空配列（ボタンを表示しない）で返す
+        <List headerButtons={() => {return []}}>
+            <Table {...tableProps} rowKey="id">
+                <Table.Column
+                    dataIndex={["profile_id"]}
+                    title="ダウンロードユーザー"
+                    render={(value) =>
+                        profileIsLoading ? (
+                            <>Loading...</>
+                        ) : (
+                            profileData?.data?.find((item) => item.id === value)
+                                ?.first_name
+                        )
+                    }
+                />
+                <Table.Column
+                    dataIndex={["image_id"]}
+                    title="ダウンロード画像"
+                    render={(value) =>
+                        imageIsLoading ? (
+                            <>Loading...</>
+                        ) : (
+                            imageData?.data?.find((item) => item.id === value)
+                                ?.name
+                        )
+                    }
+                />
+                <Table.Column dataIndex="client_ip" title="IPアドレス" />
+                <Table.Column
+                    dataIndex={["created_at"]}
+                    title="作成日（画像ダウンロード日）"
+                    render={(value: any) => <DateField value={value} />}
+                />
+                <Table.Column
+                    title="操作"
+                    dataIndex="actions"
+                    render={(_, record: BaseRecord) => (
+                        <Space>
+                            <ShowButton
+                                hideText
+                                size="small"
+                                recordItemId={record.id}
+                            />
+                            <DeleteButton
+                                hideText
+                                size="small"
+                                recordItemId={record.id}
+                            />
+                        </Space>
+                    )}
+                />
+            </Table>
+        </List>
+    );
 };

--- a/vite-app-ant/src/pages/download_logs/list.tsx
+++ b/vite-app-ant/src/pages/download_logs/list.tsx
@@ -42,8 +42,7 @@ export const DownloadLogsList = () => {
                         profileIsLoading ? (
                             <>Loading...</>
                         ) : (
-                            profileData?.data?.find((item) => item.id === value)
-                                ?.first_name
+                            `${profileData?.data?.find((item) => item.id === value)?.last_name} ${profileData?.data?.find((item) => item.id === value)?.first_name}`
                         )
                     }
                 />

--- a/vite-app-ant/src/pages/download_logs/show.tsx
+++ b/vite-app-ant/src/pages/download_logs/show.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Show } from "@refinedev/antd";
-import { useShow } from "@refinedev/core";
+import { useShow, useOne } from "@refinedev/core";
 import { Typography, Descriptions } from "antd";
 
 const { Title } = Typography;
@@ -10,15 +10,23 @@ export const DownloadLogsShow = () => {
     const { data, isLoading } = queryResult;
     const record = data?.data;
 
+    const { data: profileData } = useOne({
+        resource: "profiles",
+        id: record?.profile_id ?? "",
+        queryOptions: {
+            enabled: !!record?.profile_id,
+        },
+    });
+
     return (
-        <Show>
+        <Show headerButtons={() => []}>
             <Title level={5}>ダウンロードログ詳細</Title>
             <Descriptions bordered>
                 <Descriptions.Item label="ID" span={3}>
                     {record?.id}
                 </Descriptions.Item>
-                <Descriptions.Item label="ユーザーID" span={3}>
-                    {record?.user_id}
+                <Descriptions.Item label="ダウンロードユーザー" span={3}>
+                    {profileData?.data ? `${profileData.data.last_name} ${profileData.data.first_name}` : "Loading..."}
                 </Descriptions.Item>
                 <Descriptions.Item label="画像ID" span={3}>
                     {record?.image_id}

--- a/vite-app-ant/src/pages/download_logs/show.tsx
+++ b/vite-app-ant/src/pages/download_logs/show.tsx
@@ -1,5 +1,32 @@
-import { AntdInferencer } from "@refinedev/inferencer/antd";
+import React from "react";
+import { Show } from "@refinedev/antd";
+import { useShow } from "@refinedev/core";
+import { Typography, Descriptions } from "antd";
+
+const { Title } = Typography;
 
 export const DownloadLogsShow = () => {
-    return <AntdInferencer />;
+    const { queryResult } = useShow();
+    const { data, isLoading } = queryResult;
+    const record = data?.data;
+
+    return (
+        <Show>
+            <Title level={5}>ダウンロードログ詳細</Title>
+            <Descriptions bordered>
+                <Descriptions.Item label="ID" span={3}>
+                    {record?.id}
+                </Descriptions.Item>
+                <Descriptions.Item label="ユーザーID" span={3}>
+                    {record?.user_id}
+                </Descriptions.Item>
+                <Descriptions.Item label="画像ID" span={3}>
+                    {record?.image_id}
+                </Descriptions.Item>
+                <Descriptions.Item label="作成日時" span={3}>
+                    {record?.created_at && new Date(record.created_at).toLocaleString('ja-JP')}
+                </Descriptions.Item>
+            </Descriptions>
+        </Show>
+    );
 };

--- a/vite-app-ant/src/pages/images/list.tsx
+++ b/vite-app-ant/src/pages/images/list.tsx
@@ -43,14 +43,14 @@ export const ImagesList = () => {
     return (
         <List headerButtons={renderHeaderButtons}>
             <Table {...tableProps} rowKey="id">
-                <Table.Column dataIndex="name" title="Name" />
+                <Table.Column dataIndex="name" title="名前" />
                 <Table.Column
                     dataIndex={["created_at"]}
-                    title=""
+                    title="作成日時"
                     render={(value: any) => <DateField value={value} />}
                 />
                 <Table.Column
-                    title="Actions"
+                    title="操作"
                     dataIndex="actions"
                     render={(_, record: BaseRecord) => (
                         <Space>

--- a/vite-app-ant/src/pages/login/index.tsx
+++ b/vite-app-ant/src/pages/login/index.tsx
@@ -10,22 +10,19 @@ interface LoginFormValues {
   password: string;
 }
 
-export const LoginPage: React.FC = () => {
-  const [form] = Form.useForm<LoginFormValues>();
+export const LoginPage = () => {
   const { mutate: login } = useLogin<LoginFormValues>();
-  const [loading, setLoading] = useState(false);
+  const [form] = Form.useForm<LoginFormValues>();
 
-  const handleUserSelect = ({ email, password }: LoginFormValues) => {
-    form.setFieldsValue({ email, password });
+  const handleUserSelect = (user: { email: string; password: string }) => {
+    form.setFieldsValue({
+      email: user.email,
+      password: user.password,
+    });
   };
 
-  const onFinish = async (values: LoginFormValues) => {
-    setLoading(true);
-    try {
-      await login(values);
-    } finally {
-      setLoading(false);
-    }
+  const onFinish = (values: LoginFormValues) => {
+    login(values);
   };
 
   return (
@@ -33,51 +30,59 @@ export const LoginPage: React.FC = () => {
       style={{
         height: "100vh",
         display: "flex",
-        alignItems: "center",
         justifyContent: "center",
+        alignItems: "center",
+        background: "#f0f2f5",
       }}
     >
-      <Card style={{ width: 400 }}>
-        <Title level={3} style={{ textAlign: "center", marginBottom: 24 }}>
+      <Card
+        style={{
+          width: "400px",
+          boxShadow: "0 4px 8px rgba(0,0,0,0.1)",
+        }}
+      >
+        <Title level={3} style={{ textAlign: "center", marginBottom: "24px" }}>
           ログイン
         </Title>
-        <DebugUserSelect onUserSelect={handleUserSelect} />
-        <Form<LoginFormValues>
+        <Form
           form={form}
-          layout="vertical"
+          name="login"
           onFinish={onFinish}
+          layout="vertical"
           requiredMark={false}
         >
           <Form.Item
-            name="email"
             label="メールアドレス"
+            name="email"
             rules={[
-              { required: true, message: "メールアドレスを入力してください" },
-              { type: "email", message: "有効なメールアドレスを入力してください" },
+              {
+                required: true,
+                message: "メールアドレスを入力してください",
+              },
             ]}
           >
-            <Input size="large" placeholder="example@kater.jp" />
+            <Input size="large" />
           </Form.Item>
           <Form.Item
-            name="password"
             label="パスワード"
-            rules={[{ required: true, message: "パスワードを入力してください" }]}
+            name="password"
+            rules={[
+              {
+                required: true,
+                message: "パスワードを入力してください",
+              },
+            ]}
           >
-            <Input.Password size="large" placeholder="パスワード" />
+            <Input.Password size="large" />
           </Form.Item>
           <Form.Item>
-            <Button
-              type="primary"
-              size="large"
-              htmlType="submit"
-              loading={loading}
-              block
-            >
+            <Button type="primary" htmlType="submit" size="large" block>
               ログイン
             </Button>
           </Form.Item>
         </Form>
+        <DebugUserSelect onUserSelect={handleUserSelect} />
       </Card>
     </div>
   );
-}; 
+};


### PR DESCRIPTION
## 概要
ダウンロードログのUI改善とシードデータの日本語化を行いました。ユーザー名の表示方法を改善し、シードデータをより現実的な日本人の名前に変更することで、より使いやすいインターフェースを実現します。

## 変更内容
1. ダウンロードログ一覧画面の改善
   - ユーザー名を姓名で表示するように修正
   - より見やすい表示形式に変更

2. ダウンロードログ詳細画面の改善
   - 編集ボタンを削除
   - ユーザー名を姓名で表示するように修正

3. シードデータの改善
   - ユーザー名を日本人らしい名前に変更
     - 姓: 佐藤、鈴木、高橋、田中、伊藤、渡辺、山本、中村、小林、加藤
     - 名: 翔太、陽菜、大輝、結衣、悠真、美咲、颯太、莉子、蓮、優花
   - UUIDを固定値に変更し、再現性を確保

## 変更ファイル
- `supabase/seed.sql`
- `vite-app-ant/src/pages/download_logs/list.tsx`
- `vite-app-ant/src/pages/download_logs/show.tsx` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Image download events are now logged, capturing user, image, timestamp, and client IP information.
  - Download logs list and detail views now display related user and image information with custom tables and layouts.

- **Enhancements**
  - Resource metadata in the app sidebar includes descriptive labels and improved organization.
  - Image and download log IDs are now deterministically generated for consistency.
  - Japanese names are used for seeded user profiles and admin.

- **Bug Fixes**
  - Table column titles in the images list are now displayed in Japanese.

- **Refactor**
  - Download logs list and detail pages were rewritten for improved data presentation and relational lookups.
  - Login page refactored for cleaner logic and improved styling.

- **Chores**
  - Added the "md5" package as a dependency.
  - Minor whitespace cleanup in components.

- **Database**
  - Primary key column in the download logs table renamed for consistency.
  - Disabled seeding of download logs in the seed script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #42 #33 #40 #39 