### PR TITLE
feat: ダウンロードログのUI改善と日時表示の日本語化

### DIFF
--- a/supabase/functions/watermark-image/index.ts
+++ b/supabase/functions/watermark-image/index.ts
@@ -209,10 +209,10 @@ serve(async (req: Request) => {
     const { error: logError } = await serviceRoleClient
       .from('download_logs')
       .insert({
-        user_id: user.id,
+        profile_id: user.id,
         image_id: imageId,
         created_at: new Date().toISOString(),
-        ip_address: req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || 'unknown'
+        client_ip: req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || 'unknown'
       });
 
     if (logError) {

--- a/vite-app-ant/src/pages/download_logs/list.tsx
+++ b/vite-app-ant/src/pages/download_logs/list.tsx
@@ -31,6 +31,11 @@ export const DownloadLogsList = () => {
         },
     });
 
+    const formatDate = (date: string) => {
+        const d = new Date(date);
+        return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
+    };
+
     return (
         // ヘッダーボタンを空配列（ボタンを表示しない）で返す
         <List headerButtons={() => {return []}}>
@@ -62,7 +67,7 @@ export const DownloadLogsList = () => {
                 <Table.Column
                     dataIndex={["created_at"]}
                     title="作成日（画像ダウンロード日）"
-                    render={(value: any) => <DateField value={value} />}
+                    render={(value: any) => formatDate(value)}
                 />
                 <Table.Column
                     title="操作"

--- a/vite-app-ant/src/pages/images/list.tsx
+++ b/vite-app-ant/src/pages/images/list.tsx
@@ -40,6 +40,11 @@ export const ImagesList = () => {
         return [<CreateButton key="create" />];
     };
 
+    const formatDate = (date: string) => {
+        const d = new Date(date);
+        return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
+    };
+
     return (
         <List headerButtons={renderHeaderButtons}>
             <Table {...tableProps} rowKey="id">
@@ -47,7 +52,7 @@ export const ImagesList = () => {
                 <Table.Column
                     dataIndex={["created_at"]}
                     title="作成日時"
-                    render={(value: any) => <DateField value={value} />}
+                    render={(value: any) => formatDate(value)}
                 />
                 <Table.Column
                     title="操作"


### PR DESCRIPTION
## 概要
ダウンロードログのUI改善と日時表示の日本語化を行いました。ユーザー名の表示方法を改善し、日時表示を日本標準の形式に変更することで、より使いやすいインターフェースを実現します。

## 変更内容
1. ダウンロードログ一覧画面の改善
   - ユーザー名を姓名で表示するように修正
   - 日時表示を「YYYY年M月D日」形式に変更

2. 画像一覧画面の改善
   - 日時表示を「YYYY年M月D日」形式に変更

3. ウォーターマーク画像ダウンロード機能の修正
   - ダウンロードログのカラム名を修正（`user_id` → `profile_id`）
   - IPアドレスのカラム名を修正（`ip_address` → `client_ip`）

## 変更ファイル
- `supabase/functions/watermark-image/index.ts`
- `vite-app-ant/src/pages/download_logs/list.tsx`
- `vite-app-ant/src/pages/images/list.tsx` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Dates in tables are now displayed in Japanese format ("YYYY年M月D日") for better localization and readability.

- **Chores**
  - Updated internal field names related to user and IP address information for download logs. No visible changes to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->